### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The original creator of IKAnalyzer is [Liang-Yi Lin ](linliangyi2007@gmail.com) 
  - based on IK Analyer 2012-FF Hotfix 1 
  - added support for Lucene 5.1.0 API
 
-#Installation #
+# Installation  #
 
  - JDK8 
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
